### PR TITLE
fix: parser correctness + CLI error UX

### DIFF
--- a/Sources/CLI/CLI.swift
+++ b/Sources/CLI/CLI.swift
@@ -9,15 +9,22 @@ import simd
 enum CLIError: Error, LocalizedError {
     case unsupportedFormat(String)
     case fileNotFound(String)
+    case invalidSize(String)
+    case batchValidationFailed
     case thumbnailEncodingFailed
     case rendererCreationFailed
 
     var errorDescription: String? {
         switch self {
         case let .unsupportedFormat(ext):
-            "Unsupported file format: .\(ext) (expected .3mf or .stl)"
+            // Empty ext prints as "." — name it so the message stays legible.
+            "Unsupported file format: \(ext.isEmpty ? "(no extension)" : ".\(ext)") (expected .3mf, .stl, or .gcode)"
         case let .fileNotFound(path):
             "File not found: \(path)"
+        case let .invalidSize(detail):
+            "Invalid --size value: \(detail)"
+        case .batchValidationFailed:
+            "One or more files failed validation"
         case .thumbnailEncodingFailed:
             "Failed to encode thumbnail PNG"
         case .rendererCreationFailed:
@@ -29,7 +36,7 @@ enum CLIError: Error, LocalizedError {
 enum CLI {
     static func printUsage() {
         let usage = """
-        threemf-cli — headless thumbnail/info for .3mf and .stl files
+        threemf-cli — headless thumbnail/info for .3mf, .stl, and .gcode files
 
         Usage:
           threemf-cli info <file>
@@ -48,8 +55,12 @@ enum CLI {
                       and PASS/FAIL lines for 'validate'.
 
         Flags:
+          --size N    For 'thumbnail': output edge length in pixels (1…4096, default 512).
+          --plate N   For 'thumbnail': render only plate N (1-based) of a multi-plate 3MF.
           --cache     For 'thumbnail': read/write the shared ThumbnailCache so
                       repeated invocations reuse a previously rendered PNG.
+
+        Exit codes: 0 success · 1 runtime error (missing/corrupt/unsupported file) · 2 usage.
         """
         FileHandle.standardError.write(Data("\(usage)\n".utf8))
     }
@@ -78,14 +89,14 @@ enum CLI {
             }
         }
         if anyFailed {
-            throw CLIError.fileNotFound("one or more files failed validation")
+            throw CLIError.batchValidationFailed
         }
     }
 
     private static func infoLine(for file: URL) async -> String? {
         do {
             try ensureExists(file)
-            let format = detectFormat(file)
+            let format = try resolveFormat(file)
             let payload = try buildInfoPayload(file: file, format: format)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
@@ -99,7 +110,7 @@ enum CLI {
     private static func validateLine(for file: URL) async -> String? {
         do {
             try ensureExists(file)
-            let format = detectFormat(file)
+            let format = try resolveFormat(file)
             switch format {
             case .gcode: _ = try GCodeParser.parse(from: file)
             case .threemf, .stl: _ = try loadMesh(from: file, format: format)
@@ -114,7 +125,7 @@ enum CLI {
     /// are well-formed before farming them out to slicers.
     static func validate(file: URL) throws {
         try ensureExists(file)
-        let format = detectFormat(file)
+        let format = try resolveFormat(file)
         do {
             let payload: String
             switch format {
@@ -144,12 +155,20 @@ enum CLI {
         }
     }
 
-    /// Parses optional `--size N` flag from argv. Returns nil if absent or invalid.
-    static func parseSize(from args: [String]) -> Int? {
-        guard let idx = args.firstIndex(of: "--size"), idx + 1 < args.count else {
-            return nil
+    /// Resolves the `--size N` flag. Absent → default 512. Present but non-numeric,
+    /// non-positive, or above `maxThumbnailSize` → throws, so a typo like `--size 0` or
+    /// `--size huge` fails loudly instead of silently rendering the default (or a 0×0 image).
+    static func resolveSize(from args: [String]) throws -> Int {
+        guard let idx = args.firstIndex(of: "--size") else { return 512 }
+        guard idx + 1 < args.count else { throw CLIError.invalidSize("(missing value)") }
+        let raw = args[idx + 1]
+        guard let n = Int(raw) else {
+            throw CLIError.invalidSize("\(raw) (expected an integer 1...\(maxThumbnailSize))")
         }
-        return Int(args[idx + 1])
+        guard n > 0, n <= maxThumbnailSize else {
+            throw CLIError.invalidSize("\(n) (expected 1...\(maxThumbnailSize))")
+        }
+        return n
     }
 
     /// Parses optional `--plate N` (1-based) flag from argv. Returns nil if absent or invalid.
@@ -164,7 +183,7 @@ enum CLI {
 
     static func info(file: URL) throws {
         try ensureExists(file)
-        let format = detectFormat(file)
+        let format = try resolveFormat(file)
         let payload = try buildInfoPayload(file: file, format: format)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -240,7 +259,7 @@ enum CLI {
             return
         }
 
-        let format = detectFormat(input)
+        let format = try resolveFormat(input)
         var mesh = try loadMesh(from: input, format: format)
         // `--plate N` (1-based) renders only that plate of a multi-plate Bambu/Orca 3MF.
         if let plate, !mesh.plates.isEmpty {
@@ -280,11 +299,20 @@ enum CLI {
         case gcode
     }
 
-    static func detectFormat(_ url: URL) -> FileFormat {
+    /// Largest thumbnail edge we'll render. Above this the snapshot allocation is huge
+    /// (size² × 4 bytes × MSAA) for no practical gain; reject with a clear message instead.
+    static let maxThumbnailSize = 4096
+
+    /// Resolves the file format from its extension, throwing a clear error for anything we
+    /// don't handle. Extensionless files default to `.3mf` (archives are sometimes exported
+    /// without a suffix); any *other* unknown extension is rejected explicitly, so the user
+    /// sees "unsupported format" rather than a misleading downstream 3MF/ZIP parse error.
+    static func resolveFormat(_ url: URL) throws -> FileFormat {
         switch url.pathExtension.lowercased() {
-        case "stl": .stl
-        case "gcode": .gcode
-        default: .threemf
+        case "stl": return .stl
+        case "gcode": return .gcode
+        case "3mf", "": return .threemf
+        case let other: throw CLIError.unsupportedFormat(other)
         }
     }
 

--- a/Sources/CLI/CLI.swift
+++ b/Sources/CLI/CLI.swift
@@ -84,7 +84,9 @@ enum CLI {
             }
             for await line in group {
                 guard let line else { continue }
-                if line.hasPrefix("FAIL ") { anyFailed = true }
+                if line.hasPrefix("FAIL ") {
+                    anyFailed = true
+                }
                 FileHandle.standardOutput.write(Data("\(line)\n".utf8))
             }
         }

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -56,7 +56,9 @@ do {
             semaphore.signal()
         }
         semaphore.wait()
-        if let batchError { throw batchError }
+        if let batchError {
+            throw batchError
+        }
     case "-h", "--help", "help":
         CLI.printUsage()
         exit(0)

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -31,7 +31,7 @@ do {
             CLI.printUsage()
             exit(2)
         }
-        let size = CLI.parseSize(from: cliArgs) ?? 512
+        let size = try CLI.resolveSize(from: cliArgs)
         let useCache = cliArgs.contains("--cache")
         try CLI.thumbnail(
             input: URL(fileURLWithPath: cliArgs[2]),

--- a/Sources/PreviewExtension/HUDOverlay.swift
+++ b/Sources/PreviewExtension/HUDOverlay.swift
@@ -125,17 +125,30 @@ final class HUDOverlay: NSVisualEffectView {
 
         // Append 3MF metadata when available.
         if let md = stats.metadata {
-            if let app = md.application { lines.append("\(String(localized: "Slicer")): \(app)") }
-            if let title = md.title { lines.append("\(String(localized: "Title")): \(title)") }
-            if let designer = md.designer { lines.append("\(String(localized: "Designer")): \(designer)") }
-            if let date = md.creationDate { lines.append("\(String(localized: "Created")): \(date)") }
+            if let app = md.application {
+                lines.append("\(String(localized: "Slicer")): \(app)")
+            }
+            if let title = md.title {
+                lines.append("\(String(localized: "Title")): \(title)")
+            }
+            if let designer = md.designer {
+                lines.append("\(String(localized: "Designer")): \(designer)")
+            }
+            if let date = md.creationDate {
+                lines.append("\(String(localized: "Created")): \(date)")
+            }
         }
 
         // Bambu/Orca plate JSON: filament weight, print time, machine.
         if let bp = stats.bambuPlate {
-            if let machine = bp.machineId { lines.append("\(String(localized: "Printer")): \(machine)") }
+            if let machine = bp.machineId {
+                lines.append("\(String(localized: "Printer")): \(machine)")
+            }
             if let g = bp
-                .totalFilamentGrams { lines.append("\(String(localized: "Filament")): \(String(format: "%.1f g", g))") }
+                .totalFilamentGrams
+            {
+                lines.append("\(String(localized: "Filament")): \(String(format: "%.1f g", g))")
+            }
             if let s = bp.predictionSeconds {
                 let h = s / 3600
                 let m = (s % 3600) / 60

--- a/Sources/PreviewExtension/PreviewViewController.swift
+++ b/Sources/PreviewExtension/PreviewViewController.swift
@@ -66,11 +66,19 @@ class PreviewViewController: NSViewController, @preconcurrency QLPreviewingContr
     fileprivate func handleRootKeyDown(event: NSEvent) -> Bool {
         // Plate-cycling arrow keys work whenever plates are loaded, regardless of mode.
         let key = Int(event.keyCode)
-        if key == 123 { cyclePlate(-1); return true } // left arrow
-        if key == 124 { cyclePlate(+1); return true } // right arrow
+        if key == 123 {
+            cyclePlate(-1); return true
+        } // left arrow
+        if key == 124 {
+            cyclePlate(+1); return true
+        } // right arrow
         // Layer-stepping arrow keys (G-code mode). No-op outside G-code preview.
-        if key == 126 { stepLayer(+1); return layerScrubber != nil } // up arrow
-        if key == 125 { stepLayer(-1); return layerScrubber != nil } // down arrow
+        if key == 126 {
+            stepLayer(+1); return layerScrubber != nil
+        } // up arrow
+        if key == 125 {
+            stepLayer(-1); return layerScrubber != nil
+        } // down arrow
 
         guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else { return false }
         switch chars.lowercased() {
@@ -279,7 +287,9 @@ class PreviewViewController: NSViewController, @preconcurrency QLPreviewingContr
                   scrubber.currentLayer < total - 1
             {
                 try? await Task.sleep(nanoseconds: 33_000_000) // ~30 fps
-                if Task.isCancelled { break }
+                if Task.isCancelled {
+                    break
+                }
                 let next = min(total - 1, scrubber.currentLayer + stepSize)
                 scrubber.setLayer(next)
                 self.setVisibleToolpathLayers(through: next)
@@ -659,7 +669,9 @@ class PreviewViewController: NSViewController, @preconcurrency QLPreviewingContr
     /// Returns true if event was handled. Called from ZoomSCNView when a 3D scene is showing.
     fileprivate func handleSceneKeyDown(event: NSEvent) -> Bool {
         // Shared root shortcuts (?, arrows) take precedence so they work in 3D mode too.
-        if handleRootKeyDown(event: event) { return true }
+        if handleRootKeyDown(event: event) {
+            return true
+        }
 
         guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else { return false }
         let c = chars.lowercased()

--- a/Sources/PreviewExtension/SceneInteractionViews.swift
+++ b/Sources/PreviewExtension/SceneInteractionViews.swift
@@ -19,7 +19,9 @@ class ZoomSCNView: SCNView {
     }
 
     override func keyDown(with event: NSEvent) {
-        if keyDownHandler?(event) == true { return }
+        if keyDownHandler?(event) == true {
+            return
+        }
         super.keyDown(with: event)
     }
 
@@ -78,7 +80,9 @@ final class KeyableView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
-        if keyDownHandler?(event) == true { return }
+        if keyDownHandler?(event) == true {
+            return
+        }
         super.keyDown(with: event)
     }
 }

--- a/Sources/Shared/BambuModelConfig.swift
+++ b/Sources/Shared/BambuModelConfig.swift
@@ -55,7 +55,9 @@ public struct BambuModelConfig: Sendable, Hashable {
     public var objectPlateIndex: [String: Int] {
         var map: [String: Int] = [:]
         for (idx, plate) in plates.enumerated() {
-            for oid in plate.objectIds { map[oid] = idx }
+            for oid in plate.objectIds {
+                map[oid] = idx
+            }
         }
         return map
     }
@@ -145,7 +147,9 @@ public struct BambuModelConfig: Sendable, Hashable {
             var r = 0
             for i in 0 ..< n {
                 guard pos < bits.count else { break }
-                if bits[pos] { r |= (1 << i) }
+                if bits[pos] {
+                    r |= (1 << i)
+                }
                 pos += 1
             }
             return r
@@ -161,19 +165,27 @@ public struct BambuModelConfig: Sendable, Hashable {
                     state = sc
                 } else {
                     let e = read(4)
-                    if e == 14 { state = 17 + read(8) } else { state = 3 + e }
+                    if e == 14 {
+                        state = 17 + read(8)
+                    } else {
+                        state = 3 + e
+                    }
                 }
                 states.append(state)
             } else {
                 _ = read(2) // special_side
-                for _ in 0 ... nss { decode(depth: depth + 1) } // nss + 1 children
+                for _ in 0 ... nss {
+                    decode(depth: depth + 1)
+                } // nss + 1 children
             }
         }
         decode(depth: 0)
         let painted = states.filter { $0 >= 1 }
         guard !painted.isEmpty else { return 0 }
         var counts: [Int: Int] = [:]
-        for s in painted { counts[s, default: 0] += 1 }
+        for s in painted {
+            counts[s, default: 0] += 1
+        }
         return counts.max { $0.value < $1.value }?.key ?? 0
     }
 
@@ -270,12 +282,16 @@ private final class ModelSettingsDelegate: NSObject, XMLParserDelegate {
         namespaceURI _: String?,
         qualifiedName _: String?
     ) {
-        if !stack.isEmpty { stack.removeLast() }
+        if !stack.isEmpty {
+            stack.removeLast()
+        }
         switch elementName {
         case "object":
             currentObjectId = nil
         case "plate":
-            if let plate = currentPlate { plates.append(plate) }
+            if let plate = currentPlate {
+                plates.append(plate)
+            }
             currentPlate = nil
         default:
             break

--- a/Sources/Shared/GCodeParser.swift
+++ b/Sources/Shared/GCodeParser.swift
@@ -168,12 +168,20 @@ public enum GCodeParser {
         guard !segments.isEmpty else {
             throw GCodeParserError.noSegments
         }
+        // Sanitize the ETA before it leaves the parser. Crafted coords (Inf via a `1e999`
+        // token, or huge-finite via `1e30`) drive this non-finite or absurdly large; a
+        // downstream `Int(estimatedSeconds)` (HUD ETA, CLI) would then trap and crash the
+        // preview. Clamp to [0, 100 years] — anything beyond that is meaningless and
+        // keeps every consumer's Int cast in range. Root-cause fix, protects all callers.
+        let safeSeconds = estimatedSeconds.isFinite
+            ? min(max(estimatedSeconds, 0), 3_153_600_000) // 100 * 365.25 * 24 * 3600
+            : 0
         return ToolpathData(
             segments: segments,
             layerCount: layerIndex + 1,
             totalExtrudedMM: totalExtrudedMM,
             totalTravelMM: totalTravelMM,
-            estimatedSeconds: estimatedSeconds
+            estimatedSeconds: safeSeconds
         )
     }
 

--- a/Sources/Shared/GCodeParser.swift
+++ b/Sources/Shared/GCodeParser.swift
@@ -91,7 +91,9 @@ public enum GCodeParser {
                 // beyond 1 means a different command (G10, G11) which we ignore for now.
                 if p + 2 < endOfCode {
                     let c2 = base[p + 2]
-                    if c2 >= 0x30, c2 <= 0x39 { continue } // G10, G11, G12, etc.
+                    if c2 >= 0x30, c2 <= 0x39 {
+                        continue
+                    } // G10, G11, G12, etc.
                 }
                 p += 2
 
@@ -111,9 +113,15 @@ public enum GCodeParser {
                     while p < endOfCode {
                         let c = base[p]
                         // End of token when we hit whitespace or another letter.
-                        if c == 0x20 || c == 0x09 { break }
-                        if c >= 0x41, c <= 0x5A { break } // A-Z
-                        if c >= 0x61, c <= 0x7A { break } // a-z
+                        if c == 0x20 || c == 0x09 {
+                            break
+                        }
+                        if c >= 0x41, c <= 0x5A {
+                            break
+                        } // A-Z
+                        if c >= 0x61, c <= 0x7A {
+                            break
+                        } // a-z
                         p += 1
                     }
                     let value = parseFloat(base: base, start: valStart, end: p)
@@ -191,8 +199,11 @@ public enum GCodeParser {
         var i = start
         guard i < end else { return 0 }
         var negative = false
-        if base[i] == 0x2D { negative = true; i += 1 }
-        else if base[i] == 0x2B { i += 1 }
+        if base[i] == 0x2D {
+            negative = true; i += 1
+        } else if base[i] == 0x2B {
+            i += 1
+        }
         var intPart: Double = 0
         while i < end, base[i] >= 0x30, base[i] <= 0x39 {
             intPart = intPart * 10 + Double(base[i] - 0x30)
@@ -212,8 +223,11 @@ public enum GCodeParser {
         if i < end, base[i] == 0x65 || base[i] == 0x45 {
             i += 1
             var expNeg = false
-            if i < end, base[i] == 0x2D { expNeg = true; i += 1 }
-            else if i < end, base[i] == 0x2B { i += 1 }
+            if i < end, base[i] == 0x2D {
+                expNeg = true; i += 1
+            } else if i < end, base[i] == 0x2B {
+                i += 1
+            }
             var exp = 0
             while i < end, base[i] >= 0x30, base[i] <= 0x39 {
                 exp = exp * 10 + Int(base[i] - 0x30)

--- a/Sources/Shared/MeshData.swift
+++ b/Sources/Shared/MeshData.swift
@@ -213,7 +213,9 @@ public struct MeshData {
                 }
                 newIndices.append(mapped)
             }
-            if hasMats, t < triangleMaterials.count { newTriMats.append(triangleMaterials[t]) }
+            if hasMats, t < triangleMaterials.count {
+                newTriMats.append(triangleMaterials[t])
+            }
         }
 
         var sub = MeshData(

--- a/Sources/Shared/STLParser.swift
+++ b/Sources/Shared/STLParser.swift
@@ -326,9 +326,24 @@ private struct VertexKey: Hashable {
     let iz: Int32
 
     init(x: Float, y: Float, z: Float) {
-        ix = Int32((x * 10000).rounded())
-        iy = Int32((y * 10000).rounded())
-        iz = Int32((z * 10000).rounded())
+        ix = Self.quantize(x)
+        iy = Self.quantize(y)
+        iz = Self.quantize(z)
+    }
+
+    /// Quantize a coordinate to a fixed-point bucket without ever trapping.
+    /// WHY: `Int32(Float)` fatal-errors on NaN/Inf and on any finite value outside
+    /// Int32's range. A crafted STL can supply NaN/Inf (binary reinterpret, or an ASCII
+    /// `1e999` that overflows to Inf) or a huge finite coord (1e30 → 1e34 after scaling) —
+    /// each would crash the Quick Look extension (DoS on preview). Guard finiteness, then
+    /// clamp to the representable range so degenerate vertices collapse harmlessly instead.
+    @inline(__always)
+    private static func quantize(_ v: Float) -> Int32 {
+        guard v.isFinite else { return 0 }
+        let scaled = (Double(v) * 10000).rounded()
+        if scaled >= Double(Int32.max) { return Int32.max }
+        if scaled <= Double(Int32.min) { return Int32.min }
+        return Int32(scaled)
     }
 }
 

--- a/Sources/Shared/STLParser.swift
+++ b/Sources/Shared/STLParser.swift
@@ -239,14 +239,18 @@ public enum STLParser {
                             indices.append(idx)
                         }
                         // Bound aggregate triangle count under aggressive crafted input.
-                        if indices.count >= maxTriangles * 3 { break }
+                        if indices.count >= maxTriangles * 3 {
+                            break
+                        }
                     }
                 }
                 // Advance to next newline.
                 while pos < count, base[pos] != 0x0A {
                     pos += 1
                 }
-                if pos < count { pos += 1 }
+                if pos < count {
+                    pos += 1
+                }
             }
         }
 
@@ -271,7 +275,9 @@ public enum STLParser {
         let start = pos
         while pos < count {
             let c = base[pos]
-            if c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0D { break }
+            if c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0D {
+                break
+            }
             pos += 1
         }
         return start < pos ? start ..< pos : nil
@@ -285,8 +291,11 @@ public enum STLParser {
         guard i < end else { return 0 }
 
         var negative = false
-        if base[i] == 0x2D { negative = true; i += 1 }
-        else if base[i] == 0x2B { i += 1 }
+        if base[i] == 0x2D {
+            negative = true; i += 1
+        } else if base[i] == 0x2B {
+            i += 1
+        }
 
         var intPart: Double = 0
         while i < end, base[i] >= 0x30, base[i] <= 0x39 {
@@ -307,8 +316,11 @@ public enum STLParser {
         if i < end, base[i] == 0x65 || base[i] == 0x45 {
             i += 1
             var expNeg = false
-            if i < end, base[i] == 0x2D { expNeg = true; i += 1 }
-            else if i < end, base[i] == 0x2B { i += 1 }
+            if i < end, base[i] == 0x2D {
+                expNeg = true; i += 1
+            } else if i < end, base[i] == 0x2B {
+                i += 1
+            }
             var exp = 0
             while i < end, base[i] >= 0x30, base[i] <= 0x39 {
                 exp = exp * 10 + Int(base[i] - 0x30)
@@ -341,8 +353,12 @@ private struct VertexKey: Hashable {
     private static func quantize(_ v: Float) -> Int32 {
         guard v.isFinite else { return 0 }
         let scaled = (Double(v) * 10000).rounded()
-        if scaled >= Double(Int32.max) { return Int32.max }
-        if scaled <= Double(Int32.min) { return Int32.min }
+        if scaled >= Double(Int32.max) {
+            return Int32.max
+        }
+        if scaled <= Double(Int32.min) {
+            return Int32.min
+        }
         return Int32(scaled)
     }
 }

--- a/Sources/Shared/SceneBuilder.swift
+++ b/Sources/Shared/SceneBuilder.swift
@@ -179,8 +179,12 @@ public enum SceneBuilder {
 
         // Stable order: default group (-1) first, then materials in ascending order.
         let orderedKeys = groups.keys.sorted { a, b in
-            if a == -1 { return true }
-            if b == -1 { return false }
+            if a == -1 {
+                return true
+            }
+            if b == -1 {
+                return false
+            }
             return a < b
         }
 
@@ -206,11 +210,15 @@ public enum SceneBuilder {
             orderedKeys.append(-1)
         }
         for m in mesh.triangleMaterials.sorted() where m >= 0 {
-            if seen.insert(m).inserted { orderedKeys.append(m) }
+            if seen.insert(m).inserted {
+                orderedKeys.append(m)
+            }
         }
 
         return orderedKeys.map { key in
-            if key == -1 { return defaultMaterial }
+            if key == -1 {
+                return defaultMaterial
+            }
             guard key < mesh.materials.count, let color = mesh.materials[key].color else {
                 return defaultMaterial
             }

--- a/Sources/Shared/ThreeMFExtractor.swift
+++ b/Sources/Shared/ThreeMFExtractor.swift
@@ -73,7 +73,9 @@ public enum ThreeMFExtractor {
         var scanned = 0
         for entry in archive {
             scanned += 1
-            if scanned > maxFallbackEntries { break }
+            if scanned > maxFallbackEntries {
+                break
+            }
             let path = entry.path.lowercased()
             if path.hasSuffix(".png"),
                path.hasPrefix("metadata/") || path.hasPrefix("thumbnail/")
@@ -133,14 +135,18 @@ public enum ThreeMFExtractor {
 
         for entry in archive {
             scanned += 1
-            if scanned > maxFallbackEntries { break }
+            if scanned > maxFallbackEntries {
+                break
+            }
             let lower = entry.path.lowercased()
             guard lower.hasPrefix("metadata/"), lower.hasSuffix(".png") else { continue }
             let basename = String(lower.split(separator: "/").last ?? "")
             guard let (kind, idx) = Self.plateKindAndIndex(basename: basename) else { continue }
             guard entry.uncompressedSize <= UInt64(maxThumbnailSize) else { continue }
             // Prefer the `plate_` render over `top_` for the same index; keep the first of a kind.
-            if let existing = byIndex[idx], existing.kind <= kind { continue }
+            if let existing = byIndex[idx], existing.kind <= kind {
+                continue
+            }
             byIndex[idx] = (kind, entry.path)
         }
 
@@ -206,7 +212,9 @@ public enum ThreeMFExtractor {
             } catch {
                 continue
             }
-            if let info = BambuPlateInfo.parse(data) { return info }
+            if let info = BambuPlateInfo.parse(data) {
+                return info
+            }
         }
         return nil
     }
@@ -220,7 +228,9 @@ public enum ThreeMFExtractor {
         for (prefix, kind) in [("plate_", 0), ("top_", 1)] {
             guard basename.hasPrefix(prefix), basename.hasSuffix(".png") else { continue }
             let mid = basename.dropFirst(prefix.count).dropLast(4) // strip prefix and ".png"
-            if let n = Int(mid) { return (kind, n) }
+            if let n = Int(mid) {
+                return (kind, n)
+            }
         }
         return nil
     }

--- a/Sources/Shared/ThreeMFMeshParser.swift
+++ b/Sources/Shared/ThreeMFMeshParser.swift
@@ -247,73 +247,82 @@ public enum ThreeMFMeshParser {
 
         if !result.buildItems.isEmpty {
             for item in result.buildItems {
-                let meshObjId = resolveObjectMesh(
+                // Flatten the item's object into concrete sub-meshes, each with its fully
+                // composed transform (build-item ∘ nested component transforms). The common
+                // Bambu/Orca case (object has its own mesh, no components) yields exactly one
+                // emission at `item.transform`, so this is behavior-preserving there.
+                let emissions = expandObject(
                     objectId: item.objectId,
+                    transform: item.transform,
                     components: result.components,
-                    objectMeshes: objectMeshes
+                    objectMeshes: objectMeshes,
+                    depth: 0,
+                    visiting: []
                 )
-                guard let mesh = objectMeshes[meshObjId] else { continue }
-                guard canAppend(verts: mesh.vertices.count, tris: mesh.indices.count / 3) else {
-                    log.error("Skipping object \(meshObjId, privacy: .public) — would exceed aggregate caps")
-                    continue
-                }
-
-                let baseOffset = UInt32(allVertices.count)
-                let transform = item.transform
-
-                if transform == [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0] {
-                    // Identity transform — skip per-vertex math
-                    allVertices.append(contentsOf: mesh.vertices)
-                } else {
-                    allVertices.reserveCapacity(allVertices.count + mesh.vertices.count)
-                    let m = transform
-                    for v in mesh.vertices {
-                        let x = (m[0] * v.x) + (m[3] * v.y) + (m[6] * v.z) + m[9]
-                        let y = (m[1] * v.x) + (m[4] * v.y) + (m[7] * v.z) + m[10]
-                        let z = (m[2] * v.x) + (m[5] * v.y) + (m[8] * v.z) + m[11]
-                        allVertices.append(simd_float3(x, y, z))
+                for emission in emissions {
+                    guard let mesh = objectMeshes[emission.meshObjectId] else { continue }
+                    guard canAppend(verts: mesh.vertices.count, tris: mesh.indices.count / 3) else {
+                        log.error("Skipping object \(emission.meshObjectId, privacy: .public) — would exceed aggregate caps")
+                        continue
                     }
-                }
-                allIndices.reserveCapacity(allIndices.count + mesh.indices.count)
-                let triBase = allIndices.count / 3
-                for idx in mesh.indices {
-                    allIndices.append(idx + baseOffset)
-                }
-                let triCountThisItem = mesh.indices.count / 3
-                // Color: Bambu assigns one material per object (via extruder); otherwise
-                // fall back to the mesh's own core-spec per-triangle materials.
-                if bambuColor {
-                    // Base color = object's extruder; per-triangle paint overrides it.
-                    let baseMatIdx = bambuObjMaterial[item.objectId] ?? -1
-                    if allTriangleMats.count < triBase {
-                        allTriangleMats.append(contentsOf: repeatElement(-1, count: triBase - allTriangleMats.count))
-                    }
-                    let paint = objectPaintStates[meshObjId]
-                    if let paint, paint.count == triCountThisItem {
-                        for state in paint {
-                            // state is a 1-based extruder; palette index = state - 1.
-                            if state >= 1, state - 1 < bambuPaletteCount {
-                                allTriangleMats.append(state - 1)
-                            } else {
-                                allTriangleMats.append(baseMatIdx)
-                            }
-                        }
+
+                    let baseOffset = UInt32(allVertices.count)
+                    let transform = emission.transform
+
+                    if transform == [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0] {
+                        // Identity transform — skip per-vertex math
+                        allVertices.append(contentsOf: mesh.vertices)
                     } else {
-                        allTriangleMats.append(contentsOf: repeatElement(baseMatIdx, count: triCountThisItem))
+                        allVertices.reserveCapacity(allVertices.count + mesh.vertices.count)
+                        let m = transform
+                        for v in mesh.vertices {
+                            let x = (m[0] * v.x) + (m[3] * v.y) + (m[6] * v.z) + m[9]
+                            let y = (m[1] * v.x) + (m[4] * v.y) + (m[7] * v.z) + m[10]
+                            let z = (m[2] * v.x) + (m[5] * v.y) + (m[8] * v.z) + m[11]
+                            allVertices.append(simd_float3(x, y, z))
+                        }
                     }
-                } else if !mesh.triangleMaterials.isEmpty {
-                    if allTriangleMats.count < triBase {
-                        allTriangleMats.append(contentsOf: repeatElement(-1, count: triBase - allTriangleMats.count))
+                    allIndices.reserveCapacity(allIndices.count + mesh.indices.count)
+                    let triBase = allIndices.count / 3
+                    for idx in mesh.indices {
+                        allIndices.append(idx + baseOffset)
                     }
-                    allTriangleMats.append(contentsOf: mesh.triangleMaterials)
-                }
-                // Plate membership (independent of color) so the preview can show one plate.
-                if bambuHasPlates {
-                    let plateIdx = bambuObjPlate[item.objectId] ?? -1
-                    if allTrianglePlates.count < triBase {
-                        allTrianglePlates.append(contentsOf: repeatElement(-1, count: triBase - allTrianglePlates.count))
+                    let triCountThisItem = mesh.indices.count / 3
+                    // Color: Bambu assigns one material per object (via extruder); otherwise
+                    // fall back to the mesh's own core-spec per-triangle materials.
+                    if bambuColor {
+                        // Base color = object's extruder; per-triangle paint overrides it.
+                        let baseMatIdx = bambuObjMaterial[item.objectId] ?? -1
+                        if allTriangleMats.count < triBase {
+                            allTriangleMats.append(contentsOf: repeatElement(-1, count: triBase - allTriangleMats.count))
+                        }
+                        let paint = objectPaintStates[emission.meshObjectId]
+                        if let paint, paint.count == triCountThisItem {
+                            for state in paint {
+                                // state is a 1-based extruder; palette index = state - 1.
+                                if state >= 1, state - 1 < bambuPaletteCount {
+                                    allTriangleMats.append(state - 1)
+                                } else {
+                                    allTriangleMats.append(baseMatIdx)
+                                }
+                            }
+                        } else {
+                            allTriangleMats.append(contentsOf: repeatElement(baseMatIdx, count: triCountThisItem))
+                        }
+                    } else if !mesh.triangleMaterials.isEmpty {
+                        if allTriangleMats.count < triBase {
+                            allTriangleMats.append(contentsOf: repeatElement(-1, count: triBase - allTriangleMats.count))
+                        }
+                        allTriangleMats.append(contentsOf: mesh.triangleMaterials)
                     }
-                    allTrianglePlates.append(contentsOf: repeatElement(plateIdx, count: triCountThisItem))
+                    // Plate membership (independent of color) so the preview can show one plate.
+                    if bambuHasPlates {
+                        let plateIdx = bambuObjPlate[item.objectId] ?? -1
+                        if allTrianglePlates.count < triBase {
+                            allTrianglePlates.append(contentsOf: repeatElement(-1, count: triBase - allTrianglePlates.count))
+                        }
+                        allTrianglePlates.append(contentsOf: repeatElement(plateIdx, count: triCountThisItem))
+                    }
                 }
             }
         } else {
@@ -401,6 +410,9 @@ public enum ThreeMFMeshParser {
         let parser = XMLParser(data: xmlData)
         parser.delegate = delegate
         parser.shouldProcessNamespaces = false
+        // Defense-in-depth: never fetch external DTDs/entities. This matches Foundation's
+        // default, but we set it explicitly so the XXE-off posture survives future refactors.
+        parser.shouldResolveExternalEntities = false
         guard parser.parse() else { return nil }
         // Filter out-of-range indices so SceneKit never sees a bad triangle.
         let vCount = UInt32(delegate.vertices.count)
@@ -422,20 +434,65 @@ public enum ThreeMFMeshParser {
         return (delegate.vertices, safeIndices)
     }
 
-    private static func resolveObjectMesh(
+    /// Max component-nesting depth. 3MF assemblies are shallow in practice; the cap also
+    /// bounds recursion on a malformed/circular file (belt-and-suspenders with the cycle set).
+    private static let maxComponentDepth = 16
+
+    /// Flattens an object into the list of `(meshObjectId, transform)` to emit, resolving
+    /// `<component>` references recursively and composing their transforms. An object may
+    /// contribute its own mesh *and* components. Each component's transform maps the child
+    /// into this object's coordinate space, so it composes child-first with the inherited
+    /// transform. Depth-bounded and cycle-guarded so a circular reference can't recurse
+    /// without end. Replaces the old single-id resolver, which dropped every component
+    /// transform and rendered only the first sub-mesh.
+    private static func expandObject(
         objectId: String,
+        transform: [Float],
         components: [ComponentRef],
-        objectMeshes: [String: (vertices: [simd_float3], indices: [UInt32], triangleMaterials: [Int])]
-    ) -> String {
+        objectMeshes: [String: (vertices: [simd_float3], indices: [UInt32], triangleMaterials: [Int])],
+        depth: Int,
+        visiting: Set<String>
+    ) -> [(meshObjectId: String, transform: [Float])] {
+        guard depth < maxComponentDepth, !visiting.contains(objectId) else { return [] }
+        var out: [(meshObjectId: String, transform: [Float])] = []
+
+        // The object's own mesh (if any) is emitted at the inherited transform.
         if objectMeshes[objectId] != nil {
-            return objectId
+            out.append((objectId, transform))
         }
-        for comp in components {
-            if comp.parentObjectId == objectId, objectMeshes[comp.objectId] != nil {
-                return comp.objectId
+
+        var childVisiting = visiting
+        childVisiting.insert(objectId)
+        for comp in components where comp.parentObjectId == objectId {
+            let composed = composeTransforms(comp.transform, transform)
+            out.append(contentsOf: expandObject(
+                objectId: comp.objectId,
+                transform: composed,
+                components: components,
+                objectMeshes: objectMeshes,
+                depth: depth + 1,
+                visiting: childVisiting
+            ))
+        }
+        return out
+    }
+
+    /// Composes two 3MF transforms (12-float, 4×3, row-vector convention) so that applying
+    /// the result equals applying `inner` then `outer`: `v · result == (v · inner) · outer`.
+    /// Each matrix's implicit last column is (0,0,0,1); row 3 is the translation.
+    static func composeTransforms(_ inner: [Float], _ outer: [Float]) -> [Float] {
+        func e(_ m: [Float], _ r: Int, _ c: Int) -> Float { m[r * 3 + c] }
+        var out = [Float](repeating: 0, count: 12)
+        for i in 0 ..< 4 {
+            for j in 0 ..< 3 {
+                var s = e(inner, i, 0) * e(outer, 0, j)
+                    + e(inner, i, 1) * e(outer, 1, j)
+                    + e(inner, i, 2) * e(outer, 2, j)
+                if i == 3 { s += e(outer, 3, j) } // inner's implicit w=1 carries outer's translation
+                out[i * 3 + j] = s
             }
         }
-        return objectId
+        return out
     }
 }
 
@@ -571,6 +628,10 @@ private struct ByteScanner {
     private var currentMatGroupStart: Int = 0
 
     private var currentObjectId: String?
+    /// Object-level default material (3MF core `pid`/`pindex`): triangles that carry no
+    /// material of their own inherit these. nil when the object sets no default.
+    private var currentObjectPid: String?
+    private var currentObjectPindex: Int?
     private var currentVertices: [simd_float3] = []
     private var currentIndices: [UInt32] = []
     private var currentTriMaterials: [Int] = []
@@ -873,10 +934,13 @@ private struct ByteScanner {
             currentIndices.append(v2)
             currentIndices.append(v3)
             // Resolve material: pid identifies a basematerials group, p1 is the entry within it.
-            // We map (pid, p1) to a global material index. Default to 0 when unspecified.
-            if let pid, let p1 = p1Idx, let range = materialGroups[pid] {
-                let gIdx = range.lowerBound + p1
-                if gIdx < range.upperBound {
+            // A triangle without its own pid/p1 inherits the object's default (pid/pindex),
+            // per 3MF core spec — the common shape for single-color objects.
+            let effectivePid = pid ?? currentObjectPid
+            let effectiveP1 = p1Idx ?? currentObjectPindex
+            if let effectivePid, let effectiveP1, let range = materialGroups[effectivePid] {
+                let gIdx = range.lowerBound + effectiveP1
+                if gIdx >= range.lowerBound, gIdx < range.upperBound {
                     currentTriMaterials.append(gIdx)
                     hasAnyMaterial = true
                 } else {
@@ -897,7 +961,11 @@ private struct ByteScanner {
     }
 
     private mutating func parseObject() {
-        currentObjectId = readStringAttribute("id")
+        let attrs = readAttributes(["id", "pid", "pindex"])
+        currentObjectId = attrs["id"]
+        // Object-level default material — inherited by triangles lacking their own pid/p1.
+        currentObjectPid = attrs["pid"]
+        currentObjectPindex = attrs["pindex"].flatMap { Int($0) }
         currentVertices = []
         currentIndices = []
         currentTriMaterials = []

--- a/Sources/Shared/ThreeMFMeshParser.swift
+++ b/Sources/Shared/ThreeMFMeshParser.swift
@@ -183,7 +183,9 @@ public enum ThreeMFMeshParser {
                 log.error("Rejected suspicious component path: \(comp.path, privacy: .public)")
                 continue
             }
-            if objectMeshes[comp.objectId] != nil { continue }
+            if objectMeshes[comp.objectId] != nil {
+                continue
+            }
 
             if let entry = archive[normalized] {
                 let data: Data
@@ -262,7 +264,10 @@ public enum ThreeMFMeshParser {
                 for emission in emissions {
                     guard let mesh = objectMeshes[emission.meshObjectId] else { continue }
                     guard canAppend(verts: mesh.vertices.count, tris: mesh.indices.count / 3) else {
-                        log.error("Skipping object \(emission.meshObjectId, privacy: .public) — would exceed aggregate caps")
+                        log
+                            .error(
+                                "Skipping object \(emission.meshObjectId, privacy: .public) — would exceed aggregate caps"
+                            )
                         continue
                     }
 
@@ -294,7 +299,10 @@ public enum ThreeMFMeshParser {
                         // Base color = object's extruder; per-triangle paint overrides it.
                         let baseMatIdx = bambuObjMaterial[item.objectId] ?? -1
                         if allTriangleMats.count < triBase {
-                            allTriangleMats.append(contentsOf: repeatElement(-1, count: triBase - allTriangleMats.count))
+                            allTriangleMats.append(contentsOf: repeatElement(
+                                -1,
+                                count: triBase - allTriangleMats.count
+                            ))
                         }
                         let paint = objectPaintStates[emission.meshObjectId]
                         if let paint, paint.count == triCountThisItem {
@@ -311,7 +319,10 @@ public enum ThreeMFMeshParser {
                         }
                     } else if !mesh.triangleMaterials.isEmpty {
                         if allTriangleMats.count < triBase {
-                            allTriangleMats.append(contentsOf: repeatElement(-1, count: triBase - allTriangleMats.count))
+                            allTriangleMats.append(contentsOf: repeatElement(
+                                -1,
+                                count: triBase - allTriangleMats.count
+                            ))
                         }
                         allTriangleMats.append(contentsOf: mesh.triangleMaterials)
                     }
@@ -319,7 +330,10 @@ public enum ThreeMFMeshParser {
                     if bambuHasPlates {
                         let plateIdx = bambuObjPlate[item.objectId] ?? -1
                         if allTrianglePlates.count < triBase {
-                            allTrianglePlates.append(contentsOf: repeatElement(-1, count: triBase - allTrianglePlates.count))
+                            allTrianglePlates.append(contentsOf: repeatElement(
+                                -1,
+                                count: triBase - allTrianglePlates.count
+                            ))
                         }
                         allTrianglePlates.append(contentsOf: repeatElement(plateIdx, count: triCountThisItem))
                     }
@@ -481,14 +495,18 @@ public enum ThreeMFMeshParser {
     /// the result equals applying `inner` then `outer`: `v · result == (v · inner) · outer`.
     /// Each matrix's implicit last column is (0,0,0,1); row 3 is the translation.
     static func composeTransforms(_ inner: [Float], _ outer: [Float]) -> [Float] {
-        func e(_ m: [Float], _ r: Int, _ c: Int) -> Float { m[r * 3 + c] }
+        func e(_ m: [Float], _ r: Int, _ c: Int) -> Float {
+            m[r * 3 + c]
+        }
         var out = [Float](repeating: 0, count: 12)
         for i in 0 ..< 4 {
             for j in 0 ..< 3 {
                 var s = e(inner, i, 0) * e(outer, 0, j)
                     + e(inner, i, 1) * e(outer, 1, j)
                     + e(inner, i, 2) * e(outer, 2, j)
-                if i == 3 { s += e(outer, 3, j) } // inner's implicit w=1 carries outer's translation
+                if i == 3 {
+                    s += e(outer, 3, j)
+                } // inner's implicit w=1 carries outer's translation
                 out[i * 3 + j] = s
             }
         }
@@ -536,7 +554,9 @@ private final class NSXMLFallbackDelegate: NSObject, XMLParserDelegate {
         case "mesh":
             inMesh = true
         case "vertex" where inMesh:
-            if vertices.count >= maxVertices { parser.abortParsing(); return }
+            if vertices.count >= maxVertices {
+                parser.abortParsing(); return
+            }
             guard
                 let xs = attrs["x"], let ys = attrs["y"], let zs = attrs["z"],
                 let x = Float(xs), let y = Float(ys), let z = Float(zs),
@@ -544,7 +564,9 @@ private final class NSXMLFallbackDelegate: NSObject, XMLParserDelegate {
             else { return }
             vertices.append(simd_float3(x, y, z))
         case "triangle" where inMesh:
-            if indices.count / 3 >= maxTriangles { parser.abortParsing(); return }
+            if indices.count / 3 >= maxTriangles {
+                parser.abortParsing(); return
+            }
             guard
                 let v1s = attrs["v1"], let v2s = attrs["v2"], let v3s = attrs["v3"],
                 let v1 = UInt32(v1s), let v2 = UInt32(v2s), let v3 = UInt32(v3s)
@@ -564,7 +586,9 @@ private final class NSXMLFallbackDelegate: NSObject, XMLParserDelegate {
         qualifiedName _: String?
     ) {
         let local = elementName.split(separator: ":").last.map(String.init) ?? elementName
-        if local.lowercased() == "mesh" { inMesh = false }
+        if local.lowercased() == "mesh" {
+            inMesh = false
+        }
     }
 }
 
@@ -701,7 +725,9 @@ private struct ByteScanner {
                             indices: currentIndices,
                             triangleMaterials: mats
                         )
-                        if hasAnyPaint { objectPaintStates[objId] = currentPaintStates }
+                        if hasAnyPaint {
+                            objectPaintStates[objId] = currentPaintStates
+                        }
                     }
                     currentObjectId = nil
                     hasAnyMaterial = false
@@ -792,19 +818,37 @@ private struct ByteScanner {
         // Match common tag names by length then first char
         switch len {
         case 4:
-            if matchesCaseInsensitiveAt(nameStart, "mesh") { return .mesh }
-            if matchesCaseInsensitiveAt(nameStart, "item") { return .item }
-            if matchesCaseInsensitiveAt(nameStart, "base") { return .base }
+            if matchesCaseInsensitiveAt(nameStart, "mesh") {
+                return .mesh
+            }
+            if matchesCaseInsensitiveAt(nameStart, "item") {
+                return .item
+            }
+            if matchesCaseInsensitiveAt(nameStart, "base") {
+                return .base
+            }
         case 6:
-            if matchesCaseInsensitiveAt(nameStart, "vertex") { return .vertex }
-            if matchesCaseInsensitiveAt(nameStart, "object") { return .object }
+            if matchesCaseInsensitiveAt(nameStart, "vertex") {
+                return .vertex
+            }
+            if matchesCaseInsensitiveAt(nameStart, "object") {
+                return .object
+            }
         case 8:
-            if matchesCaseInsensitiveAt(nameStart, "triangle") { return .triangle }
-            if matchesCaseInsensitiveAt(nameStart, "metadata") { return .metadata }
+            if matchesCaseInsensitiveAt(nameStart, "triangle") {
+                return .triangle
+            }
+            if matchesCaseInsensitiveAt(nameStart, "metadata") {
+                return .metadata
+            }
         case 9:
-            if matchesCaseInsensitiveAt(nameStart, "component") { return .component }
+            if matchesCaseInsensitiveAt(nameStart, "component") {
+                return .component
+            }
         case 13:
-            if matchesCaseInsensitiveAt(nameStart, "basematerials") { return .basematerials }
+            if matchesCaseInsensitiveAt(nameStart, "basematerials") {
+                return .basematerials
+            }
         default:
             break
         }
@@ -843,7 +887,9 @@ private struct ByteScanner {
                 pos += 1
             }
             let valEnd = pos
-            if pos < count { pos += 1 } // skip closing quote
+            if pos < count {
+                pos += 1
+            } // skip closing quote
 
             // Match single-char attribute names x, y, z
             if attrLen == 1 {
@@ -899,7 +945,9 @@ private struct ByteScanner {
                 pos += 1
             }
             let valEnd = pos
-            if pos < count { pos += 1 }
+            if pos < count {
+                pos += 1
+            }
 
             // Match v1, v2, v3 (vertex indices) and p1 (per-tri material) and pid (group id).
             if attrLen == 2 {
@@ -953,7 +1001,9 @@ private struct ByteScanner {
             if let paintHex {
                 let state = BambuModelConfig.decodePaintColor(paintHex)
                 currentPaintStates.append(state)
-                if state >= 1 { hasAnyPaint = true }
+                if state >= 1 {
+                    hasAnyPaint = true
+                }
             } else {
                 currentPaintStates.append(0)
             }
@@ -1081,7 +1131,9 @@ private struct ByteScanner {
                 pos += 1
             }
             let valEnd = pos
-            if pos < count { pos += 1 }
+            if pos < count {
+                pos += 1
+            }
 
             if names.contains(attrName) {
                 result[attrName] = stringFromBytes(valStart, valEnd)
@@ -1125,7 +1177,9 @@ private struct ByteScanner {
     @inline(__always)
     private mutating func skipToTagEnd() {
         _ = skipTo(ByteScanner.gt)
-        if pos < count { pos += 1 }
+        if pos < count {
+            pos += 1
+        }
     }
 
     @inline(__always)
@@ -1133,7 +1187,9 @@ private struct ByteScanner {
         let utf8 = str.utf8
         guard offset + utf8.count <= count else { return false }
         for (i, ch) in utf8.enumerated() {
-            if base[offset + i] != ch { return false }
+            if base[offset + i] != ch {
+                return false
+            }
         }
         return true
     }
@@ -1144,7 +1200,9 @@ private struct ByteScanner {
         guard offset + utf8.count <= count else { return false }
         for (i, ch) in utf8.enumerated() {
             let b = base[offset + i]
-            if b != ch, b != ch - 32 { return false } // lowercase or uppercase
+            if b != ch, b != ch - 32 {
+                return false
+            } // lowercase or uppercase
         }
         return true
     }

--- a/Sources/Shared/ThumbnailCache.swift
+++ b/Sources/Shared/ThumbnailCache.swift
@@ -66,7 +66,9 @@ public enum ThumbnailCache {
         // Oldest-accessed first.
         let oldestFirst = stats.sorted { $0.accessed < $1.accessed }
         for entry in oldestFirst {
-            if totalBytes <= maxCacheBytes { break }
+            if totalBytes <= maxCacheBytes {
+                break
+            }
             try? fm.removeItem(at: entry.url)
             totalBytes -= entry.size
         }

--- a/Tests/CLITests.swift
+++ b/Tests/CLITests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import XCTest
+
+/// Covers the CLI's error-UX surface: format resolution, --size validation, and the
+/// missing/unsupported-file paths. CLI.swift is compiled into this test bundle (see
+/// project.yml) so these pure helpers are unit-testable without spawning the binary.
+final class CLITests: XCTestCase {
+    // MARK: - resolveFormat
+
+    func testResolveFormat_knownExtensions() throws {
+        XCTAssertEqual(try CLI.resolveFormat(URL(fileURLWithPath: "m.stl")), .stl)
+        XCTAssertEqual(try CLI.resolveFormat(URL(fileURLWithPath: "m.STL")), .stl) // case-insensitive
+        XCTAssertEqual(try CLI.resolveFormat(URL(fileURLWithPath: "m.gcode")), .gcode)
+        XCTAssertEqual(try CLI.resolveFormat(URL(fileURLWithPath: "m.3mf")), .threemf)
+    }
+
+    func testResolveFormat_extensionlessDefaultsTo3MF() throws {
+        // Archives are sometimes exported without a suffix — keep the lenient default.
+        XCTAssertEqual(try CLI.resolveFormat(URL(fileURLWithPath: "model")), .threemf)
+    }
+
+    func testResolveFormat_unknownExtension_throwsClearError() {
+        XCTAssertThrowsError(try CLI.resolveFormat(URL(fileURLWithPath: "report.txt"))) { error in
+            // The message must name the bad extension and the supported set — not a
+            // misleading downstream "cannot open .3mf archive".
+            let msg = (error as? CLIError)?.errorDescription ?? ""
+            XCTAssertTrue(msg.contains(".txt"), msg)
+            XCTAssertTrue(msg.contains(".stl") && msg.contains(".gcode"), msg)
+        }
+    }
+
+    // MARK: - resolveSize
+
+    func testResolveSize_absent_defaults512() throws {
+        XCTAssertEqual(try CLI.resolveSize(from: ["thumbnail", "a", "b"]), 512)
+    }
+
+    func testResolveSize_valid() throws {
+        XCTAssertEqual(try CLI.resolveSize(from: ["thumbnail", "a", "b", "--size", "1024"]), 1024)
+    }
+
+    func testResolveSize_zeroOrNegative_throws() {
+        // The bug this guards: --size 0 → CGSize(0,0) snapshot → broken/blank image.
+        XCTAssertThrowsError(try CLI.resolveSize(from: ["--size", "0"]))
+        XCTAssertThrowsError(try CLI.resolveSize(from: ["--size", "-5"]))
+    }
+
+    func testResolveSize_nonNumeric_throwsInsteadOfSilentDefault() {
+        // Old behavior silently rendered 512 on a typo; now it fails loudly.
+        XCTAssertThrowsError(try CLI.resolveSize(from: ["--size", "huge"]))
+    }
+
+    func testResolveSize_aboveCap_throws() {
+        XCTAssertThrowsError(try CLI.resolveSize(from: ["--size", "\(CLI.maxThumbnailSize + 1)"]))
+    }
+
+    func testResolveSize_missingValue_throws() {
+        XCTAssertThrowsError(try CLI.resolveSize(from: ["thumbnail", "a", "b", "--size"]))
+    }
+
+    // MARK: - missing / unsupported file paths (end-to-end through a command)
+
+    func testValidate_missingFile_throwsFileNotFound() {
+        let url = URL(fileURLWithPath: "/nonexistent/\(UUID().uuidString).stl")
+        XCTAssertThrowsError(try CLI.validate(file: url)) { error in
+            XCTAssertTrue((error as? CLIError)?.errorDescription?.contains("File not found") ?? false)
+        }
+    }
+
+    func testValidate_unsupportedExtension_throwsUnsupported() throws {
+        // A real file with an unsupported extension must fail at format resolution,
+        // not with a confusing parse error.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString).appendingPathExtension("txt")
+        try Data("not a model".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertThrowsError(try CLI.validate(file: url)) { error in
+            XCTAssertTrue((error as? CLIError)?.errorDescription?.contains("Unsupported file format") ?? false)
+        }
+    }
+}

--- a/Tests/GCodeParserTests.swift
+++ b/Tests/GCodeParserTests.swift
@@ -32,6 +32,26 @@ final class GCodeParserTests: XCTestCase {
         XCTAssertEqual(travels, 1)
     }
 
+    func testParse_craftedCoords_estimatedSecondsStaysFiniteAndInIntRange() throws {
+        // Crafted G-code: `1e999` overflows to +Inf, `1e30` is huge-finite. Either would
+        // make estimatedSeconds non-finite / > Int.max, and the HUD's Int(...) cast would
+        // trap (crash the preview). The parser must sanitize it before returning.
+        let gcode = """
+        G0 X0 Y0 Z0.2 F1
+        G1 X1e999 Y0 E1 F1
+        G1 X1e30 Y1e30 E2 F1
+        """
+        let url = try writeTempFile(string: gcode)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let toolpath = try GCodeParser.parse(from: url)
+        XCTAssertTrue(toolpath.estimatedSeconds.isFinite)
+        XCTAssertGreaterThanOrEqual(toolpath.estimatedSeconds, 0)
+        // The whole point: the value survives an Int() cast without trapping.
+        XCTAssertLessThanOrEqual(toolpath.estimatedSeconds, Double(Int.max))
+        _ = Int(toolpath.estimatedSeconds.rounded())
+    }
+
     func testParse_multipleLayers_detected() throws {
         let gcode = """
         G0 X0 Y0 Z0.2

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -83,7 +83,9 @@ final class PerformanceTests: XCTestCase {
                 var attr: UInt16 = 0
                 data.append(Data(bytes: &attr, count: 2))
                 emitted += 1
-                if emitted >= count { break outer }
+                if emitted >= count {
+                    break outer
+                }
             }
         }
         try data.write(to: url)

--- a/Tests/STLParserTests.swift
+++ b/Tests/STLParserTests.swift
@@ -307,8 +307,12 @@ class STLParserTests: XCTestCase {
                 quantize(b),
                 quantize(c),
             ].sorted { lhs, rhs in
-                if lhs[0] != rhs[0] { return lhs[0] < rhs[0] }
-                if lhs[1] != rhs[1] { return lhs[1] < rhs[1] }
+                if lhs[0] != rhs[0] {
+                    return lhs[0] < rhs[0]
+                }
+                if lhs[1] != rhs[1] {
+                    return lhs[1] < rhs[1]
+                }
                 return lhs[2] < rhs[2]
             }
             out.insert(q.flatMap(\.self))
@@ -340,7 +344,9 @@ class STLParserTests: XCTestCase {
                     v2: (x + 1, y, z),
                     v3: (x, y + 1, z)
                 ))
-                if out.count >= count { break outer }
+                if out.count >= count {
+                    break outer
+                }
             }
         }
         return out

--- a/Tests/STLParserTests.swift
+++ b/Tests/STLParserTests.swift
@@ -391,6 +391,60 @@ class STLParserTests: XCTestCase {
         XCTAssertEqual(mesh.indices.count, 3) // 1 triangle, 3 indices
     }
 
+    // MARK: - Crafted-coordinate crash guards (regression: Int32(Float) trap)
+
+    func testParseBinarySTL_nonFiniteCoords_doesNotTrap() throws {
+        // A binary triangle carrying NaN and ±Inf coordinates. Before the quantize guard,
+        // VertexKey's `Int32(Float)` cast fatal-errored on NaN/Inf — crashing the extension.
+        let data = makeBinarySTL(triangles: [
+            Triangle(
+                normal: (0, 0, 1),
+                v1: (.nan, 0, 0),
+                v2: (.infinity, 1, 0),
+                v3: (-.infinity, 0, 1)
+            ),
+        ])
+        let url = try writeTempFile(data: data, ext: "stl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Contract is "no trap": it parses (degenerate coords collapse) or throws — never crashes.
+        let mesh = try STLParser.parseMesh(from: url)
+        XCTAssertGreaterThan(mesh.vertices.count, 0)
+    }
+
+    func testParseBinarySTL_hugeFiniteCoords_doesNotTrap() throws {
+        // Finite but far outside Int32 range after *10000 scaling (1e30 → 1e34).
+        // `Int32(1e34)` also traps; the clamp path must handle this.
+        let data = makeBinarySTL(triangles: [
+            Triangle(normal: (0, 0, 1), v1: (1e30, -1e30, 0), v2: (1, 0, 0), v3: (0, 1, 0)),
+        ])
+        let url = try writeTempFile(data: data, ext: "stl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let mesh = try STLParser.parseMesh(from: url)
+        XCTAssertEqual(mesh.indices.count, 3)
+    }
+
+    func testParseASCIISTL_overflowExponent_doesNotTrap() throws {
+        // `1e999` overflows Float to +Inf in parseFloatBytes; the vertex key must not trap.
+        let ascii = """
+        solid overflow
+          facet normal 0 0 1
+            outer loop
+              vertex 1e999 0 0
+              vertex 1 0 0
+              vertex 0 1 0
+            endloop
+          endfacet
+        endsolid overflow
+        """
+        let url = try writeTempFile(string: ascii, ext: "stl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let mesh = try STLParser.parseMesh(from: url)
+        XCTAssertEqual(mesh.indices.count, 3)
+    }
+
     func testParseASCIISTL_tabSeparatedAndCRLF() throws {
         // Mix of tabs, multiple spaces, and CRLF — common when files come from Windows tools.
         let ascii =

--- a/Tests/ThreeMFExtractorPlatesTests.swift
+++ b/Tests/ThreeMFExtractorPlatesTests.swift
@@ -33,8 +33,12 @@ struct ThreeMFExtractorPlatesTests {
             "Metadata/plate_2.png", "Metadata/plate_2_small.png", "Metadata/top_2.png",
             "Metadata/thumbnail.png", "3D/3dmodel.model",
         ] {
-            try archive.addEntry(with: path, type: .file, uncompressedSize: UInt32(png.count),
-                                 provider: { p, n in png.subdata(in: p ..< p + n) })
+            try archive.addEntry(
+                with: path,
+                type: .file,
+                uncompressedSize: UInt32(png.count),
+                provider: { p, n in png.subdata(in: p ..< p + n) }
+            )
         }
         defer { try? FileManager.default.removeItem(at: url) }
 

--- a/Tests/ThreeMFMeshParserTests.swift
+++ b/Tests/ThreeMFMeshParserTests.swift
@@ -77,6 +77,147 @@ class ThreeMFMeshParserTests: XCTestCase {
         XCTAssertEqual(v0.y, 200.0, accuracy: 0.01)
     }
 
+    func testParse3MF_componentTransforms_composedAndAllEmitted() throws {
+        // Object 3 is an assembly: two components referencing objects 1 and 2, each with
+        // its own translation. A correct renderer emits BOTH sub-meshes at their translated
+        // positions. Regression for: (A) component transform ignored, (B) only first
+        // component rendered.
+        let modelXML = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <object id="1" type="model">
+              <mesh>
+                <vertices>
+                  <vertex x="0" y="0" z="0" /><vertex x="1" y="0" z="0" /><vertex x="0" y="1" z="0" />
+                </vertices>
+                <triangles><triangle v1="0" v2="1" v3="2" /></triangles>
+              </mesh>
+            </object>
+            <object id="2" type="model">
+              <mesh>
+                <vertices>
+                  <vertex x="0" y="0" z="0" /><vertex x="1" y="0" z="0" /><vertex x="0" y="1" z="0" />
+                </vertices>
+                <triangles><triangle v1="0" v2="1" v3="2" /></triangles>
+              </mesh>
+            </object>
+            <object id="3" type="model">
+              <components>
+                <component objectid="1" transform="1 0 0 0 1 0 0 0 1 100 0 0" />
+                <component objectid="2" transform="1 0 0 0 1 0 0 0 1 0 100 0" />
+              </components>
+            </object>
+          </resources>
+          <build>
+            <item objectid="3" />
+          </build>
+        </model>
+        """
+        let url = try make3MFFile(modelXML: modelXML)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let mesh = try ThreeMFMeshParser.parseMesh(from: url)
+
+        // Both components emitted → two triangles → six vertices.
+        XCTAssertEqual(mesh.vertices.count, 6, "both components should be emitted")
+        XCTAssertEqual(mesh.indices.count, 6)
+        // Component 1 translated +100 in x; component 2 translated +100 in y.
+        let maxX = mesh.vertices.map(\.x).max() ?? 0
+        let maxY = mesh.vertices.map(\.y).max() ?? 0
+        XCTAssertEqual(maxX, 101.0, accuracy: 0.01, "component 1's x-translation must apply")
+        XCTAssertEqual(maxY, 101.0, accuracy: 0.01, "component 2's y-translation must apply")
+    }
+
+    func testParse3MF_separateFileComponent_composesWithBuildItem() throws {
+        // Bambu-style: object 1's mesh lives in a separate ZIP entry, referenced by a
+        // component with its own transform (+50 x). The build item adds +7 y. A correct
+        // renderer composes BOTH: sub-mesh vertices land at (+50 x, +7 y). Before the
+        // expandObject fix, the separate-file path applied only the build-item transform
+        // and dropped the component's +50 x.
+        let rootModel = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+               xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06">
+          <resources>
+            <object id="1" type="model">
+              <components>
+                <component objectid="2" p:path="/3D/Objects/obj2.model" transform="1 0 0 0 1 0 0 0 1 50 0 0" />
+              </components>
+            </object>
+          </resources>
+          <build>
+            <item objectid="1" transform="1 0 0 0 1 0 0 0 1 0 7 0" />
+          </build>
+        </model>
+        """
+        let obj2Model = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <object id="2" type="model">
+              <mesh>
+                <vertices>
+                  <vertex x="0" y="0" z="0" /><vertex x="1" y="0" z="0" /><vertex x="0" y="1" z="0" />
+                </vertices>
+                <triangles><triangle v1="0" v2="1" v3="2" /></triangles>
+              </mesh>
+            </object>
+          </resources>
+        </model>
+        """
+        let url = try make3MFFile(entries: [
+            (path: "3D/3dmodel.model", content: rootModel.data(using: .utf8)!),
+            (path: "3D/Objects/obj2.model", content: obj2Model.data(using: .utf8)!),
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let mesh = try ThreeMFMeshParser.parseMesh(from: url)
+
+        XCTAssertEqual(mesh.vertices.count, 3, "the separate-file sub-mesh must be emitted")
+        let minX = mesh.vertices.map(\.x).min() ?? 0
+        let minY = mesh.vertices.map(\.y).min() ?? 0
+        // vertex (0,0,0) → component +50x → build-item +7y → (50, 7, 0)
+        XCTAssertEqual(minX, 50.0, accuracy: 0.01, "component +50 x must compose in")
+        XCTAssertEqual(minY, 7.0, accuracy: 0.01, "build-item +7 y must compose in")
+    }
+
+    func testParse3MF_objectLevelMaterial_inheritedByTriangles() throws {
+        // Core-spec single-color object: the material is set at the OBJECT level via
+        // pid/pindex; the triangle carries no material of its own. It must inherit the
+        // object's material (index 0), not render uncolored (-1). Common shape for
+        // single-color CAD/PrusaSlicer exports.
+        let modelXML = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <basematerials id="1">
+              <base name="red" displaycolor="#FF0000" />
+              <base name="green" displaycolor="#00FF00" />
+            </basematerials>
+            <object id="2" type="model" pid="1" pindex="1">
+              <mesh>
+                <vertices>
+                  <vertex x="0" y="0" z="0" /><vertex x="1" y="0" z="0" /><vertex x="0" y="1" z="0" />
+                </vertices>
+                <triangles><triangle v1="0" v2="1" v3="2" /></triangles>
+              </mesh>
+            </object>
+          </resources>
+          <build><item objectid="2" /></build>
+        </model>
+        """
+        let url = try make3MFFile(modelXML: modelXML)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let mesh = try ThreeMFMeshParser.parseMesh(from: url)
+
+        XCTAssertEqual(mesh.materials.count, 2)
+        XCTAssertEqual(mesh.triangleMaterials.count, 1)
+        // pindex=1 → the second material (green), inherited by the un-attributed triangle.
+        XCTAssertEqual(mesh.triangleMaterials.first, 1, "triangle must inherit object's pindex material")
+    }
+
     func testParse3MF_noModel_throws() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/Tests/ThreeMFMeshParserTests.swift
+++ b/Tests/ThreeMFMeshParserTests.swift
@@ -167,8 +167,8 @@ class ThreeMFMeshParserTests: XCTestCase {
         </model>
         """
         let url = try make3MFFile(entries: [
-            (path: "3D/3dmodel.model", content: rootModel.data(using: .utf8)!),
-            (path: "3D/Objects/obj2.model", content: obj2Model.data(using: .utf8)!),
+            (path: "3D/3dmodel.model", content: XCTUnwrap(rootModel.data(using: .utf8))),
+            (path: "3D/Objects/obj2.model", content: XCTUnwrap(obj2Model.data(using: .utf8))),
         ])
         defer { try? FileManager.default.removeItem(at: url) }
 

--- a/Tests/ThreeMFPlateColorTests.swift
+++ b/Tests/ThreeMFPlateColorTests.swift
@@ -83,7 +83,7 @@ struct ThreeMFPlateColorTests {
         #expect(mesh.trianglePlates == [0, 1]) // obj1→plateA(0), obj2→plateB(1)
     }
 
-    // Single object, multi-color via per-triangle paint_color (the Ender_Egg case).
+    /// Single object, multi-color via per-triangle paint_color (the Ender_Egg case).
     private static let paintedModel = """
     <?xml version="1.0" encoding="UTF-8"?>
     <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
@@ -115,8 +115,12 @@ struct ThreeMFPlateColorTests {
         let archive = try Archive(url: url, accessMode: .create)
         func add(_ path: String, _ s: String) throws {
             let data = Data(s.utf8)
-            try archive.addEntry(with: path, type: .file, uncompressedSize: UInt32(data.count),
-                                 provider: { p, n in data.subdata(in: p ..< p + n) })
+            try archive.addEntry(
+                with: path,
+                type: .file,
+                uncompressedSize: UInt32(data.count),
+                provider: { p, n in data.subdata(in: p ..< p + n) }
+            )
         }
         try add("3D/3dmodel.model", Self.paintedModel)
         try add("Metadata/model_settings.config", Self.paintedModelSettings)

--- a/project.yml
+++ b/project.yml
@@ -175,6 +175,9 @@ targets:
     sources:
       - Tests
       - Sources/Shared
+      # CLI.swift only (not main.swift — top-level exec code can't live in a test bundle).
+      # Compiles alongside Sources/Shared so CLI/CLIError logic is unit-testable.
+      - Sources/CLI/CLI.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.andreymaltsev.3mf-quicklook.tests
@@ -182,3 +185,4 @@ targets:
     dependencies:
       - package: ZIPFoundation
       - sdk: SceneKit.framework
+      - sdk: AppKit.framework


### PR DESCRIPTION
## Summary
Non-crash correctness fixes across the 3MF/STL/G-code parsers, plus CLI error-UX hardening. Split out from the session's audit work. Bambu/Orca (the primary path) is unaffected — verified by the existing color/plate suites staying green.

## Parser correctness
- **Int(Float) crash guards** (`STLParser`, `GCodeParser`): a crafted file with NaN/Inf/huge coordinates could trap `Int32(Float)`/`Int(Float)` and crash the Quick Look preview (a DoS). STL vertex quantize and the G-code ETA now guard `isFinite` + clamp.
- **3MF `<component>` transform composition** (`ThreeMFMeshParser`): component transforms were parsed but never applied — multi-part assemblies rendered at the origin, and only the first sub-mesh appeared. Now recursively expanded and composed (inline + separate-file), cycle-guarded against circular references.
- **Object-level material inheritance**: `<object pid pindex>` was ignored, so single-color core-spec exports rendered gray. Triangles now inherit the object default.

## CLI error UX (`Sources/CLI`)
- Unsupported extensions get a clear `Unsupported file format: .txt (expected .3mf, .stl, or .gcode)` instead of a misleading ".3mf archive" error.
- `--size` validates (rejects non-numeric / `0` / oversized) instead of a silent 512 default or a broken 0×0 render.
- Fixed stale usage text and a mislabeled batch error; documented exit codes (`0` success · `1` runtime · `2` usage).
- CLI logic is now unit-testable (`CLI.swift` compiled into the test target).

## Tests
Regression tests added for every fix (STL/G-code crash inputs, component composition inline + separate-file, object-level material, CLI resolveFormat/resolveSize/missing/unsupported). **73 tests, 0 failures** via `xcodebuild ... -scheme ThreeMFTests test`. CLI also verified end-to-end against the built binary (messages + exit codes).